### PR TITLE
feat: enhance model configuration support

### DIFF
--- a/config_v5.schema.json
+++ b/config_v5.schema.json
@@ -1,0 +1,609 @@
+{
+    "type": "object",
+    "properties": {
+        "lmStudio": {
+            "type": "object",
+            "properties": {
+                "port": {
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "host": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "ollama": {
+            "type": "object",
+            "properties": {
+                "port": {
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "host": {
+                    "type": "string"
+                },
+                "path": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "client": {
+            "type": "object",
+            "properties": {
+                "socketTimeout": {
+                    "type": "integer"
+                },
+                "connectTimeout": {
+                    "type": "integer"
+                },
+                "requestTimeout": {
+                    "type": "integer"
+                },
+                "retry": {
+                    "type": "integer",
+                    "minimum": -2147483648,
+                    "maximum": 2147483647
+                },
+                "delayBeforeRetry": {
+                    "type": "integer"
+                }
+            }
+        },
+        "apiProviders": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#/$defs/ApiProvider"
+            }
+        }
+    },
+    "$defs": {
+        "ApiProvider": {
+            "anyOf": [
+                {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "apiKey": {
+                                    "type": "string"
+                                },
+                                "modelList": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "temperature": {
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            },
+                                            "extraParameters": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "extraBody": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    }
+                                }
+                            },
+                            "required": [
+                                "apiKey",
+                                "modelList"
+                            ]
+                        },
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": [
+                                        "Claude"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "apiKey": {
+                                    "type": "string"
+                                },
+                                "modelList": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "temperature": {
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            },
+                                            "extraParameters": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "extraBody": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    }
+                                }
+                            },
+                            "required": [
+                                "apiKey"
+                            ]
+                        },
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": [
+                                        "DashScope"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "apiKey": {
+                                    "type": "string"
+                                },
+                                "modelList": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "temperature": {
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            },
+                                            "extraParameters": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "extraBody": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    }
+                                }
+                            },
+                            "required": [
+                                "apiKey"
+                            ]
+                        },
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": [
+                                        "DeepSeek"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "apiKey": {
+                                    "type": "string"
+                                },
+                                "modelList": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "temperature": {
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            },
+                                            "extraParameters": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "extraBody": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    }
+                                }
+                            },
+                            "required": [
+                                "apiKey",
+                                "modelList"
+                            ]
+                        },
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": [
+                                        "Gemini"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "apiKey": {
+                                    "type": "string"
+                                },
+                                "modelList": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "temperature": {
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            },
+                                            "extraParameters": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "extraBody": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    }
+                                }
+                            },
+                            "required": [
+                                "apiKey"
+                            ]
+                        },
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": [
+                                        "Mistral"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "baseUrl": {
+                                    "type": "string"
+                                },
+                                "apiKey": {
+                                    "type": "string"
+                                },
+                                "modelList": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "temperature": {
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            },
+                                            "extraParameters": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "extraBody": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    }
+                                },
+                                "extraRequest": {
+                                    "anyOf": []
+                                }
+                            },
+                            "required": [
+                                "baseUrl",
+                                "apiKey",
+                                "modelList"
+                            ]
+                        },
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": [
+                                        "OpenAi"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "apiKey": {
+                                    "type": "string"
+                                },
+                                "modelList": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "temperature": {
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            },
+                                            "extraParameters": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "extraBody": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    }
+                                }
+                            },
+                            "required": [
+                                "apiKey",
+                                "modelList"
+                            ]
+                        },
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": [
+                                        "OpenRouter"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "apiKey": {
+                                    "type": "string"
+                                },
+                                "modelList": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "temperature": {
+                                                "type": [
+                                                    "number",
+                                                    "null"
+                                                ]
+                                            },
+                                            "extraParameters": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            },
+                                            "extraBody": {
+                                                "type": [
+                                                    "object",
+                                                    "null"
+                                                ],
+                                                "additionalProperties": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        },
+                                        "required": [
+                                            "name"
+                                        ]
+                                    }
+                                }
+                            },
+                            "required": [
+                                "apiKey",
+                                "modelList"
+                            ]
+                        },
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": [
+                                        "SiliconFlow"
+                                    ]
+                                }
+                            },
+                            "required": [
+                                "type"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}

--- a/src/main/kotlin/io/github/stream29/proxy/Global.kt
+++ b/src/main/kotlin/io/github/stream29/proxy/Global.kt
@@ -56,7 +56,7 @@ val unused = {
         helpLogger.info("A default config file is created at ${configFile.absolutePath} with schema annotation.")
         configFile.writeText(
             """
-# ${'$'}schema: https://github.com/Stream29/ProxyAsLocalModel/raw/master/config_v4.schema.json
+# ${'$'}schema: https://github.com/Stream29/ProxyAsLocalModel/raw/master/config_v5.schema.json
 lmStudio:
   port: 1234
 ollama:

--- a/src/main/kotlin/io/github/stream29/proxy/ModelConfig.kt
+++ b/src/main/kotlin/io/github/stream29/proxy/ModelConfig.kt
@@ -1,0 +1,20 @@
+package io.github.stream29.proxy
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Configuration for a model.
+ * Breaking change in v0.1.0: Simple string format no longer supported.
+ * Use object format: { name: "model-name" } instead of "model-name"
+ */
+@Serializable
+data class ModelConfig(
+    val name: String,
+    val temperature: Double? = null,
+    val extraParameters: Map<String, String>? = null,
+    val extraBody: Map<String, String>? = null,
+) {
+    // Convenience properties for backward compatibility
+    val modelName: String get() = name
+    val temperatureOverride: Double? get() = temperature
+}

--- a/src/main/kotlin/io/github/stream29/proxy/client/ChatSSE.kt
+++ b/src/main/kotlin/io/github/stream29/proxy/client/ChatSSE.kt
@@ -12,23 +12,65 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.isActive
+import kotlinx.serialization.json.*
 
 suspend fun createStreamingChatCompletion(
     baseUrl: String,
     apiKey: String,
-    request: ChatCompletionRequest
+    request: ChatCompletionRequest,
+    extraTopLevelParams: Map<String, JsonElement>? = null,
 ): Flow<ChatCompletionChunk> {
-    val statement = globalClient.preparePost(baseUrl) {
-        url { appendPathSegments("chat", "completions") }
-        setBody(request)
-        contentType(ContentType.Application.Json)
-        accept(ContentType.Text.EventStream)
-        headers {
-            append(HttpHeaders.CacheControl, "no-cache")
-            append(HttpHeaders.Connection, "keep-alive")
-            append(HttpHeaders.Authorization, "Bearer $apiKey")
+    // Create the request body, merging extra parameters if needed
+    val requestBody =
+        if (extraTopLevelParams.isNullOrEmpty()) {
+            // No extra parameters, just use the request as-is
+            request
+        } else {
+            // We need to merge extra parameters at the top level
+            // First serialize the request to JSON
+            val requestJsonElement = globalJson.encodeToJsonElement(ChatCompletionRequest.serializer(), request)
+
+            // Convert to JsonObject and add extra parameters
+            val mergedJson =
+                buildJsonObject {
+                    // Add all fields from the original request
+                    requestJsonElement.jsonObject.forEach { (key, value) ->
+                        put(key, value)
+                    }
+                    // Add extra top-level parameters
+                    extraTopLevelParams.forEach { (key, value) ->
+                        put(key, value)
+                    }
+                }
+
+            // Return the merged JSON object as the body
+            mergedJson
         }
-    }
+
+    val statement =
+        globalClient.preparePost(baseUrl) {
+            url { appendPathSegments("chat", "completions") }
+            when (requestBody) {
+                is JsonObject -> {
+                    // For JsonObject, use TextContent to ensure proper Content-Type handling
+                    setBody(
+                        io.ktor.http.content
+                            .TextContent(requestBody.toString(), ContentType.Application.Json),
+                    )
+                }
+                else -> {
+                    // For regular objects, use normal serialization
+                    setBody(requestBody)
+                    contentType(ContentType.Application.Json)
+                }
+            }
+            accept(ContentType.Text.EventStream)
+            headers {
+                append(HttpHeaders.CacheControl, "no-cache")
+                append(HttpHeaders.Connection, "keep-alive")
+                append(HttpHeaders.Authorization, "Bearer $apiKey")
+            }
+        }
     val channel = runCatching { statement.body<ByteReadChannel>() }
         .getOrElse { return flow { throw it } }
     return flow {

--- a/src/main/kotlin/io/github/stream29/proxy/client/OpenAi.kt
+++ b/src/main/kotlin/io/github/stream29/proxy/client/OpenAi.kt
@@ -1,7 +1,9 @@
 package io.github.stream29.proxy.client
 
+import io.github.stream29.proxy.ModelConfig
 import io.github.stream29.proxy.clientLogger
 import io.github.stream29.proxy.encodeYaml
+import io.github.stream29.proxy.globalJson
 import io.github.stream29.proxy.relocate.com.aallam.openai.api.chat.ChatCompletionChunk
 import io.github.stream29.proxy.relocate.com.aallam.openai.api.chat.ChatCompletionRequest
 import io.github.stream29.proxy.relocate.com.aallam.openai.api.chat.ChatDelta
@@ -15,22 +17,231 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.*
+
+/**
+ * Convert a string value to the appropriate JsonElement type.
+ * It tries to parse as a JSON object/array first, then falls back to primitive types.
+ */
+private fun String.toJsonElement(): JsonElement {
+    // First, try to parse as a full JSON object or array
+    try {
+        val trimmed = this.trim()
+        if (trimmed.startsWith("{") && trimmed.endsWith("}")) {
+            return globalJson.parseToJsonElement(trimmed)
+        }
+        if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+            return globalJson.parseToJsonElement(trimmed)
+        }
+    } catch (e: SerializationException) {
+        // Ignore if it's not a valid JSON object/array, proceed to primitive parsing
+    }
+
+    // Fallback to parsing as a primitive type
+    // Try to parse as number first
+    this.toLongOrNull()?.let { return JsonPrimitive(it) }
+    this.toDoubleOrNull()?.let { return JsonPrimitive(it) }
+
+    // Try to parse as boolean
+    when (this.lowercase()) {
+        "true" -> return JsonPrimitive(true)
+        "false" -> return JsonPrimitive(false)
+    }
+
+    // Default to string
+    return JsonPrimitive(this)
+}
 
 @SerialName("OpenAi")
 @Serializable
 data class OpenAiConfig(
     val baseUrl: String,
     val apiKey: String,
-    val modelList: List<String>,
+    val modelList: List<ModelConfig>,
     val extraRequest: (ChatCompletionRequest) -> ChatCompletionRequest = { it },
 ) : ApiProvider {
-    override suspend fun getModelNameList(): List<String> = modelList
+    // Store model configurations for lookup
+    private val modelConfigs: Map<String, ModelConfig> by lazy {
+        modelList.associateBy { it.modelName }
+    }
+
+    override suspend fun getModelNameList(): List<String> = modelList.map { it.modelName }
+
     override suspend fun generateLStream(request: LChatCompletionRequest): Flow<LChatCompletionResponseChunk> {
-        return chatCompletionsRecording(extraRequest(request.asOpenAiRequest())).map { it.asLChatCompletionResponseChunk() }
+        val openAiRequest = request.asOpenAiRequest()
+        val (modifiedRequest, extraTopLevelParams) = applyModelConfig(openAiRequest, request.model)
+        return chatCompletionsRecording(extraRequest(modifiedRequest), extraTopLevelParams).map { it.asLChatCompletionResponseChunk() }
     }
 
     override suspend fun generateOStream(request: OChatRequest): Flow<OChatResponseChunk> {
-        return chatCompletionsRecording(extraRequest(request.asOpenAiRequest())).map { it.asOChatResponseChunk() }
+        val openAiRequest = request.asOpenAiRequest()
+        val (modifiedRequest, extraTopLevelParams) = applyModelConfig(openAiRequest, request.model)
+        return chatCompletionsRecording(extraRequest(modifiedRequest), extraTopLevelParams).map { it.asOChatResponseChunk() }
+    }
+
+    private fun applyModelConfig(
+        request: ChatCompletionRequest,
+        modelName: String,
+    ): Pair<ChatCompletionRequest, Map<String, JsonElement>?> {
+        val modelConfig = modelConfigs[modelName]
+        if (modelConfig == null) {
+            clientLogger.debug("No model config found for model: $modelName")
+            return request to null
+        }
+
+        var modifiedRequest = request
+        var topLevelParams: Map<String, JsonElement>? = null
+
+        // Apply temperature override if specified
+        modelConfig.temperature?.let { tempOverride ->
+            clientLogger.debug("Overriding temperature for model $modelName: ${request.temperature} -> $tempOverride")
+            modifiedRequest = modifiedRequest.copy(temperature = tempOverride)
+        }
+
+        // Apply extraParameters (top-level)
+        modelConfig.extraParameters?.let { extraParams ->
+            clientLogger.debug("Applying extra parameters for model $modelName: $extraParams")
+
+            // Handle known parameters that map to specific fields
+            val knownParams = mutableMapOf<String, JsonElement>()
+            val unknownParams = mutableMapOf<String, JsonElement>()
+
+            extraParams.forEach { (key, value) ->
+                val jsonValue = value.toJsonElement()
+                when (key) {
+                    "temperature" -> {
+                        // Temperature should use the dedicated field, not extraParameters
+                        clientLogger.warn(
+                            "Temperature specified in extraParameters for model $modelName will be ignored. Use the dedicated 'temperature' field instead.",
+                        )
+                        knownParams[key] = jsonValue // Track but don't apply
+                    }
+                    "max_tokens" -> {
+                        jsonValue.jsonPrimitive.intOrNull?.let { maxTokens ->
+                            clientLogger.debug("Setting max_tokens to $maxTokens")
+                            modifiedRequest = modifiedRequest.copy(maxTokens = maxTokens)
+                            knownParams[key] = jsonValue
+                        } ?: clientLogger.warn("Invalid value for max_tokens parameter: '$value' (expected integer)")
+                    }
+                    "top_p" -> {
+                        jsonValue.jsonPrimitive.doubleOrNull?.let { topP ->
+                            clientLogger.debug("Setting top_p to $topP")
+                            modifiedRequest = modifiedRequest.copy(topP = topP)
+                            knownParams[key] = jsonValue
+                        } ?: clientLogger.warn("Invalid value for top_p parameter: '$value' (expected number between 0 and 1)")
+                    }
+                    "frequency_penalty" -> {
+                        jsonValue.jsonPrimitive.doubleOrNull?.let { freqPenalty ->
+                            clientLogger.debug("Setting frequency_penalty to $freqPenalty")
+                            modifiedRequest = modifiedRequest.copy(frequencyPenalty = freqPenalty)
+                            knownParams[key] = jsonValue
+                        }
+                            ?: clientLogger.warn(
+                                "Invalid value for frequency_penalty parameter: '$value' (expected number between -2.0 and 2.0)",
+                            )
+                    }
+                    "presence_penalty" -> {
+                        jsonValue.jsonPrimitive.doubleOrNull?.let { presPenalty ->
+                            clientLogger.debug("Setting presence_penalty to $presPenalty")
+                            modifiedRequest = modifiedRequest.copy(presencePenalty = presPenalty)
+                            knownParams[key] = jsonValue
+                        }
+                            ?: clientLogger.warn(
+                                "Invalid value for presence_penalty parameter: '$value' (expected number between -2.0 and 2.0)",
+                            )
+                    }
+                    "stop" -> {
+                        // Handle stop sequences - can be a single string or array of strings
+                        val trimmedValue = value.trim()
+                        if (trimmedValue.startsWith("[") && trimmedValue.endsWith("]")) {
+                            // Try to parse as JSON array
+                            try {
+                                val stopList = globalJson.decodeFromString<List<String>>(trimmedValue)
+                                clientLogger.debug("Setting stop to list: $stopList")
+                                modifiedRequest = modifiedRequest.copy(stop = stopList)
+                                knownParams[key] = JsonArray(stopList.map { JsonPrimitive(it) })
+                            } catch (e: SerializationException) {
+                                // If parsing fails, treat as single string value
+                                clientLogger.warn(
+                                    "Failed to parse stop parameter as JSON array: '$value', treating as single string. Error: ${e.message}",
+                                )
+                                modifiedRequest = modifiedRequest.copy(stop = listOf(value))
+                                knownParams[key] = jsonValue
+                            } catch (e: IllegalArgumentException) {
+                                // Some JSON parsing errors might throw IllegalArgumentException
+                                clientLogger.warn(
+                                    "Failed to parse stop parameter as JSON array: '$value', treating as single string. Error: ${e.message}",
+                                )
+                                modifiedRequest = modifiedRequest.copy(stop = listOf(value))
+                                knownParams[key] = jsonValue
+                            }
+                        } else {
+                            // Single string
+                            clientLogger.debug("Setting stop to single value: $value")
+                            modifiedRequest = modifiedRequest.copy(stop = listOf(value))
+                            knownParams[key] = jsonValue
+                        }
+                    }
+                    "seed" -> {
+                        jsonValue.jsonPrimitive.intOrNull?.let { seed ->
+                            clientLogger.debug("Setting seed to $seed")
+                            modifiedRequest = modifiedRequest.copy(seed = seed)
+                            knownParams[key] = jsonValue
+                        } ?: clientLogger.warn("Invalid value for seed parameter: '$value' (expected integer)")
+                    }
+                    "n" -> {
+                        jsonValue.jsonPrimitive.intOrNull?.let { n ->
+                            clientLogger.debug("Setting n to $n")
+                            modifiedRequest = modifiedRequest.copy(n = n)
+                            knownParams[key] = jsonValue
+                        } ?: clientLogger.warn("Invalid value for n parameter: '$value' (expected positive integer)")
+                    }
+                    else -> {
+                        // Unknown parameters go to top-level
+                        unknownParams[key] = jsonValue
+                    }
+                }
+            }
+
+            if (unknownParams.isNotEmpty()) {
+                clientLogger.debug("Setting top-level parameters: ${unknownParams.keys}")
+                topLevelParams = unknownParams
+            }
+        }
+
+        // Apply extraBody (nested)
+        modelConfig.extraBody?.let { extraBodyParams ->
+            if (extraBodyParams.isNotEmpty()) {
+                clientLogger.debug("Applying extra body parameters for model $modelName: $extraBodyParams")
+
+                // Merge with existing extraBody if present
+                val existingExtra =
+                    when (val extra = request.extraBody) {
+                        is JsonObject -> extra.jsonObject
+                        null -> emptyMap()
+                        else -> {
+                            clientLogger.warn("Existing extraBody is not a JsonObject, it will be replaced")
+                            emptyMap()
+                        }
+                    }
+                val mergedExtra =
+                    buildJsonObject {
+                        // Add existing extra body fields
+                        existingExtra.forEach { (key, value) ->
+                            put(key, value)
+                        }
+                        // Add extra body parameters
+                        extraBodyParams.forEach { (key, value) ->
+                            put(key, value.toJsonElement())
+                        }
+                    }
+                clientLogger.debug("Setting extraBody with parameters: ${extraBodyParams.keys}")
+                modifiedRequest = modifiedRequest.copy(extraBody = mergedExtra)
+            }
+        }
+
+        return modifiedRequest to topLevelParams
     }
 
     override fun close() {}
@@ -38,13 +249,16 @@ data class OpenAiConfig(
 
 private suspend fun OpenAiConfig.chatCompletionsRecording(
     request: ChatCompletionRequest,
+    extraTopLevelParams: Map<String, JsonElement>? = null,
 ): Flow<ChatCompletionChunk> {
     val recorder = GenerationRecorder(clientLogger)
-    recorder.onRequest(request.encodeYaml())
+    val requestStr = globalJson.encodeToString(ChatCompletionRequest.serializer(), request)
+    recorder.onRequest(requestStr)
     return createStreamingChatCompletion(
         baseUrl = baseUrl,
         apiKey = apiKey,
-        request = request
+        request = request,
+        extraTopLevelParams = extraTopLevelParams,
     ).onEach { chunk ->
         chunk.choices.firstOrNull()?.delta?.run {
             content?.let { recorder.onPartialOutput(it) }

--- a/src/main/kotlin/io/github/stream29/proxy/client/OpenAiBased.kt
+++ b/src/main/kotlin/io/github/stream29/proxy/client/OpenAiBased.kt
@@ -1,5 +1,6 @@
 package io.github.stream29.proxy.client
 
+import io.github.stream29.proxy.ModelConfig
 import io.github.stream29.proxy.server.*
 import kotlinx.coroutines.flow.Flow
 import kotlinx.serialization.SerialName
@@ -10,7 +11,13 @@ import kotlinx.serialization.Serializable
 @SerialName("DashScope")
 data class DashScopeConfig(
     val apiKey: String,
-    val modelList: List<String> = listOf("qwen-max", "qwen-plus", "qwen-turbo", "qwen-long"),
+    val modelList: List<ModelConfig> =
+        listOf(
+            ModelConfig(name = "qwen-max"),
+            ModelConfig(name = "qwen-plus"),
+            ModelConfig(name = "qwen-turbo"),
+            ModelConfig(name = "qwen-long"),
+        ),
 ) : ApiProvider by OpenAiConfig(
     baseUrl = "https://dashscope.aliyuncs.com/compatible-mode/v1/",
     apiKey = apiKey,
@@ -22,7 +29,11 @@ data class DashScopeConfig(
 @SerialName("DeepSeek")
 data class DeepSeekConfig(
     val apiKey: String,
-    val modelList: List<String> = listOf("deepseek-chat", "deepseek-reasoner"),
+    val modelList: List<ModelConfig> =
+        listOf(
+            ModelConfig(name = "deepseek-chat"),
+            ModelConfig(name = "deepseek-reasoner"),
+        ),
 ) : ApiProvider by OpenAiConfig(
     baseUrl = "https://api.deepseek.com/",
     apiKey = apiKey,
@@ -34,7 +45,11 @@ data class DeepSeekConfig(
 @SerialName("Mistral")
 data class MistralConfig(
     val apiKey: String,
-    val modelList: List<String> = listOf("codestral", "mistral-large"),
+    val modelList: List<ModelConfig> =
+        listOf(
+            ModelConfig(name = "codestral"),
+            ModelConfig(name = "mistral-large"),
+        ),
 ) : ApiProvider by OpenAiConfig(
     baseUrl = "https://api.mistral.ai/v1/",
     apiKey = apiKey,
@@ -46,7 +61,7 @@ data class MistralConfig(
 @SerialName("SiliconFlow")
 data class SiliconFlowConfig(
     val apiKey: String,
-    val modelList: List<String>,
+    val modelList: List<ModelConfig>,
 ) : ApiProvider by OpenAiConfig(
     baseUrl = "https://api.siliconflow.cn/v1/",
     apiKey = apiKey,
@@ -58,7 +73,7 @@ data class SiliconFlowConfig(
 @SerialName("Gemini")
 data class GeminiConfig(
     val apiKey: String,
-    val modelList: List<String>,
+    val modelList: List<ModelConfig>,
 ) : ApiProvider by OpenAiConfig(
     baseUrl = "https://generativelanguage.googleapis.com/v1beta/openai",
     apiKey = apiKey,
@@ -70,7 +85,7 @@ data class GeminiConfig(
 @SerialName("Claude")
 data class ClaudeConfig(
     val apiKey: String,
-    val modelList: List<String>,
+    val modelList: List<ModelConfig>,
 ) : ApiProvider by OpenAiConfig(
     baseUrl = "https://api.anthropic.com/v1/",
     apiKey = apiKey,
@@ -82,7 +97,7 @@ data class ClaudeConfig(
 @SerialName("OpenRouter")
 data class OpenRouterConfig(
     val apiKey: String,
-    val modelList: List<String>,
+    val modelList: List<ModelConfig>,
 ) : ApiProvider by OpenAiConfig(
     baseUrl = "https://openrouter.ai/api/v1",
     apiKey = apiKey,


### PR DESCRIPTION
# Enhanced model configuration support

## Overview

Replace simple string-based model lists with a more comprehensive `ModelConfig` system. This allows fine-grained control over model behavior through per-model configuration of parameters.

FWIW: JetBrains AI Assistant always sends temperature=1.0, which is too high for most non-reasoning models. Which is why I think this configuration is important. 😊

## Breaking Changes

- **Model Configuration Format**: Model lists in configuration files must now use object format instead of simple strings
  - Before: `modelList: ["gpt-4", "gpt-3.5-turbo"]`
  - After: `modelList: [{ name: "gpt-4" }, { name: "gpt-3.5-turbo" }]`

# New Features

### 1. ModelConfig Data Class
Added `ModelConfig.kt` with support for:
- `name`: Model identifier (required)
- `temperature`: Override default temperature for specific models
- `extraParameters`: Top-level API parameters to include in requests
- `extraBody`: Additional parameters to merge into request body

### 2. Enhanced Parameter Handling
The OpenAI client now processes model configurations:

#### Supported Extra Parameters:
- `max_tokens`: Maximum tokens in response
- `top_p`: Nucleus sampling parameter
- `frequency_penalty`: Token frequency penalty
- `presence_penalty`: Token presence penalty
- `stop`: Stop sequences (string or array)
- `seed`: Random seed for deterministic output
- `n`: Number of completions to generate

Unknown parameters are passed as top-level JSON elements to support provider-specific features.

### 3. Example Configuration

```yaml
apiProviders:
  OpenAI:
    type: OpenAi
    baseUrl: https://api.openai.com/v1
    apiKey: sk-proj-[REDACTED]
    modelList:
      - name: gpt-4.1
        temperature: 0.1
      - name: o3
        temperature: 1.0
        extraParameters:
          service_tier: flex
          reasoning_effort: high  # defaults to medium
          # max_completion_tokens: 32768

  Gemini:
    type: Gemini
    apiKey: AIza[REDACTED]
    modelList:
      - name: gemini-2.5-pro
        temperature: 0.3
      - name: gemini-2.5-flash
        temperature: 0.1

  DeepSeek:
    type: DeepSeek
    apiKey: sk-[REDACTED]
    modelList:
      - name: deepseek-chat
        temperature: 0.1
      - name: deepseek-reasoner
        # No temperature override, uses request default

  OpenRouter:
    type: OpenRouter
    apiKey: sk-or-v1-[REDACTED]
    modelList:
      - name: deepseek/deepseek-r1
      - name: x-ai/grok-3-mini
        temperature: 0.1
      - name: x-ai/grok-3
        temperature: 0.1
```