### PR TITLE
Make yaml parser accept anchors and aliases

### DIFF
--- a/src/main/kotlin/io/github/stream29/proxy/Global.kt
+++ b/src/main/kotlin/io/github/stream29/proxy/Global.kt
@@ -39,6 +39,7 @@ val globalJson = Json {
 
 val globalYaml = Yaml(
     configuration = YamlConfiguration(
+        anchorsAndAliases = AnchorsAndAliases.Permitted(100u),
         polymorphismStyle = PolymorphismStyle.Property,
         strictMode = false,
         singleLineStringStyle = SingleLineStringStyle.PlainExceptAmbiguous,


### PR DESCRIPTION
Hey,

a simple change which should make API key handling a bit easier in config.yaml: allow usage of anchors and aliases.

Thanks for your consideration.